### PR TITLE
Support cleaning up detached dialogs

### DIFF
--- a/js/ngDialog.js
+++ b/js/ngDialog.js
@@ -860,8 +860,17 @@
                         }
                     },
 
+                    cleanupDetachedDialogs: function() {
+                        openIdStack = [];
+                        activeBodyClasses = [];
+                    },
+
                     getOpenDialogs: function() {
                         return openIdStack;
+                    },
+
+                    getActiveBodyClasses: function() {
+                        return activeBodyClasses;
                     },
 
                     getDefaults: function () {

--- a/tests/unit/ngDialog.js
+++ b/tests/unit/ngDialog.js
@@ -430,6 +430,17 @@ describe('ngDialog', function () {
       expect(elm.hasClass('ngdialog-second')).toEqual(false);
       expect(elm.hasClass('ngdialog-first')).toEqual(false);
     });
+
+    it('should properly clear the expected arrays on cleanupDetachedDialogs', function() {
+      expect(ngDialog.getOpenDialogs().length).toBe(2);
+      expect(ngDialog.getActiveBodyClasses().length).toBe(2);
+
+      ngDialog.cleanupDetachedDialogs();
+      flush();
+
+      expect(ngDialog.getOpenDialogs().length).toBe(0);
+      expect(ngDialog.getActiveBodyClasses().length).toBe(0);
+    });
   });
 
 });


### PR DESCRIPTION
Adds two public methods:

`getActiveBodyClasses`: returns the (otherwise private) `activeBodyClasses` array.

`cleanupDetachedDialogs`: sets both `openIdStack` and `activeBodyClasses` to empty arrays.

https://trello.com/c/JoEqNM5F/